### PR TITLE
Add CocoaPods support

### DIFF
--- a/PMJSON.podspec
+++ b/PMJSON.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name         = "PMJSON"
+  s.version      = "0.9"
+  s.summary      = "Pure Swift JSON encoding/decoding library"
+  s.description  = "PMJSON provides a pure-Swift strongly-typed JSON encoder/decoder as well as a set of convenience methods for converting to/from Foundation objects and for decoding JSON structures."
+
+  s.homepage     = "https://github.com/postmates/PMJSON"
+
+  s.license      = "MIT & Apache License, Version 2.0"
+
+  s.author             = { "kballard" => "kevin@sb.org" }
+  s.social_media_url   = "https://twitter.com/eridius"
+
+  s.source       = { :git => "https://github.com/postmates/PMJSON.git", :tag => "v0.9" }
+
+  s.source_files  = "Sources/*.{swift,h,m}",
+
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
+  s.watchos.deployment_target = '2.0'
+  s.tvos.deployment_target = '9.0'
+end


### PR DESCRIPTION
Hey, this pull request would close #2

- [x] create podspec
- [x] podspec passes lint

```shell
dkhamsing$ pod --version
0.39.0

dkhamsing$ pod spec lint PMJSON.podspec 

 -> PMJSON (0.9)

Analyzed 1 podspec.

PMJSON.podspec passed validation.
```

- [x] simple test demo project https://github.com/dkhamsing/PMJSON/tree/cocoapods-demo/CocoaPodsDemo

```swift
import PMJSON

let jsonString = "{\"id\":88}"
print(jsonString)
do {
    let json = try JSON.decode(jsonString)
    print (json)
} catch _ {
    print ("sad")
}             
```

```
{"id":88}
["id": JSON.Int64(88)]
```

- [ ] get setup with CocoaPods Trunk service (to publish/make it public) @kballard https://guides.cocoapods.org/making/getting-setup-with-trunk.html
- [ ] update readme with text below @kballard 

To install using [CocoaPods](https://cocoapods.org/), add the following to your Podfile:

```ruby
pod 'PMJSON', '~> 0.9'
```