### PR TITLE
Disables tests in the PM due to layout problems

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,3 +3,5 @@ import PackageDescription
 let package = Package(
     name: "PMJSON"
 )
+
+package.exclude = ["Tests"] 


### PR DESCRIPTION
Hi!

I love using PMJSON, but I had to fork it to use it with the Swift package manager.  The problem is that the structure of the Tests directory is non-compliant with the PM.  Would you be interested in addressing it?

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/postmates/pmjson/9)
<!-- Reviewable:end -->
