### PR TITLE
Quick fix for PMJSON on Linux

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -17,6 +17,10 @@
 #else
     /// A placeholder used for platforms that don't support `Decimal`.
     public typealias DecimalPlaceholder = ()
+    func ==(left:DecimalPlaceholder, right:DecimalPlaceholder) -> Bool {
+        return true
+    }
+    
 #endif
 
 /// A single JSON-compatible value.

--- a/Sources/JSONError.swift
+++ b/Sources/JSONError.swift
@@ -64,7 +64,7 @@ public enum JSONError: Error, CustomStringConvertible {
         }
     }
     
-    fileprivate func withPrefix(_ prefix: String) -> JSONError {
+    func withPrefix(_ prefix: String) -> JSONError {
         func prefixPath(_ path: String?, with prefix: String) -> String {
             guard let path = path, !path.isEmpty else { return prefix }
             if path.unicodeScalars.first == "[" {

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -420,7 +420,7 @@ public struct JSONParserIterator<Iter: IteratorProtocol>: JSONEventIterator wher
                     }
                 #endif
                 tempBuffer.append(0)
-                return .doubleValue(tempBuffer.withUnsafeBufferPointer({strtod($0.baseAddress, nil)}))
+                return .doubleValue(tempBuffer.withUnsafeBufferPointer({strtod($0.baseAddress!, nil)}))
             }
             outerLoop: while let c = base.peek() {
                 switch c {
@@ -466,7 +466,7 @@ public struct JSONParserIterator<Iter: IteratorProtocol>: JSONEventIterator wher
             tempBuffer.append(0)
             let num = tempBuffer.withUnsafeBufferPointer({ ptr -> Int64? in
                 errno = 0
-                let n = strtoll(ptr.baseAddress, nil, 10)
+                let n = strtoll(ptr.baseAddress!, nil, 10)
                 if n == 0 && errno != 0 {
                     return nil
                 } else {
@@ -483,7 +483,7 @@ public struct JSONParserIterator<Iter: IteratorProtocol>: JSONEventIterator wher
                     return try .decimalValue(tempBuffer.withUnsafeBufferPointer(parseDecimal(from:)))
                 }
             #endif
-            return .doubleValue(tempBuffer.withUnsafeBufferPointer({strtod($0.baseAddress, nil)}))
+            return .doubleValue(tempBuffer.withUnsafeBufferPointer({strtod($0.baseAddress!, nil)}))
         case "t":
             let line = self.line, column = self.column
             guard case "r"? = bump(), case "u"? = bump(), case "e"? = bump() else {

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -547,12 +547,12 @@ public struct JSONParserIterator<Iter: IteratorProtocol>: JSONEventIterator wher
         return c
     }
     
-    @inline(__always) private mutating func bumpRequired() throws -> UnicodeScalar {
+    @inline(__always) fileprivate mutating func bumpRequired() throws -> UnicodeScalar {
         guard let c = bump() else { throw error(.unexpectedEOF) }
         return c
     }
     
-    private func error(_ code: JSONParserError.Code) -> JSONParserError {
+    fileprivate func error(_ code: JSONParserError.Code) -> JSONParserError {
         return JSONParserError(code: code, line: line, column: column)
     }
     
@@ -784,7 +784,7 @@ public struct JSONParserError: Error, Hashable, CustomStringConvertible {
     }
 }
 
-struct PeekIterator<Base: IteratorProtocol> {
+fileprivate struct PeekIterator<Base: IteratorProtocol> {
     init(_ base: Base) {
         self.base = base
     }

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -547,12 +547,12 @@ public struct JSONParserIterator<Iter: IteratorProtocol>: JSONEventIterator wher
         return c
     }
     
-    @inline(__always) fileprivate mutating func bumpRequired() throws -> UnicodeScalar {
+    @inline(__always) mutating func bumpRequired() throws -> UnicodeScalar {
         guard let c = bump() else { throw error(.unexpectedEOF) }
         return c
     }
     
-    fileprivate func error(_ code: JSONParserError.Code) -> JSONParserError {
+    func error(_ code: JSONParserError.Code) -> JSONParserError {
         return JSONParserError(code: code, line: line, column: column)
     }
     

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -536,7 +536,7 @@ public struct JSONParserIterator<Iter: IteratorProtocol>: JSONEventIterator wher
         return UInt16(truncatingBitPattern: codepoint)
     }
     
-    @inline(__always) @discardableResult private mutating func bump() -> UnicodeScalar? {
+    @inline(__always) @discardableResult mutating func bump() -> UnicodeScalar? {
         let c = base.next()
         if c == "\n" {
             line += 1
@@ -561,7 +561,7 @@ public struct JSONParserIterator<Iter: IteratorProtocol>: JSONEventIterator wher
     /// The column of the last emitted token.
     public private(set) var column: UInt = 0
     
-    private var base: PeekIterator<Iter>
+    var base: PeekIterator<Iter>
     private var state: State = .initial
     private var stack: [Stack] = []
     private var tempBuffer: ContiguousArray<Int8>?
@@ -784,7 +784,7 @@ public struct JSONParserError: Error, Hashable, CustomStringConvertible {
     }
 }
 
-fileprivate struct PeekIterator<Base: IteratorProtocol> {
+struct PeekIterator<Base: IteratorProtocol> {
     init(_ base: Base) {
         self.base = base
     }

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -451,7 +451,10 @@ public struct JSONParserIterator<Iter: IteratorProtocol>: JSONEventIterator wher
                         }
                     #endif
                     tempBuffer.append(0)
-                    return .doubleValue(tempBuffer.withUnsafeBufferPointer({strtod($0.baseAddress, nil)}))
+                    #if os(iOS) || os(OSX) || os(watchOS) || os(tvOS)
+                        return .doubleValue(tempBuffer.withUnsafeBufferPointer({strtod($0.baseAddress, nil)}))
+                    #else
+                        return .doubleValue(tempBuffer.withUnsafeBufferPointer({strtod($0.baseAddress!, nil)}))
                 case "e", "E":
                     bump()
                     tempBuffer.append(Int8(truncatingBitPattern: c.value))

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -784,7 +784,7 @@ public struct JSONParserError: Error, Hashable, CustomStringConvertible {
     }
 }
 
-private struct PeekIterator<Base: IteratorProtocol> {
+struct PeekIterator<Base: IteratorProtocol> {
     init(_ base: Base) {
         self.base = base
     }

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -455,6 +455,7 @@ public struct JSONParserIterator<Iter: IteratorProtocol>: JSONEventIterator wher
                         return .doubleValue(tempBuffer.withUnsafeBufferPointer({strtod($0.baseAddress, nil)}))
                     #else
                         return .doubleValue(tempBuffer.withUnsafeBufferPointer({strtod($0.baseAddress!, nil)}))
+                    #endif
                 case "e", "E":
                     bump()
                     tempBuffer.append(Int8(truncatingBitPattern: c.value))

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -451,11 +451,7 @@ public struct JSONParserIterator<Iter: IteratorProtocol>: JSONEventIterator wher
                         }
                     #endif
                     tempBuffer.append(0)
-                    #if os(iOS) || os(OSX) || os(watchOS) || os(tvOS)
-                        return .doubleValue(tempBuffer.withUnsafeBufferPointer({strtod($0.baseAddress, nil)}))
-                    #else
-                        return .doubleValue(tempBuffer.withUnsafeBufferPointer({strtod($0.baseAddress!, nil)}))
-                    #endif
+                    return .doubleValue(tempBuffer.withUnsafeBufferPointer({strtod($0.baseAddress!, nil)}))
                 case "e", "E":
                     bump()
                     tempBuffer.append(Int8(truncatingBitPattern: c.value))


### PR DESCRIPTION
I've integrated PMJSON to parse big JSON file on a Kitura project and recognised that PMJSON 2.0.1 wouldn't compile on the ibmcom/swift-ubuntu docker image (for example). On Linux, the `DecimalPaceholder` object couldn't be compared (thus the `==` function), a few methods couldn't be called because there are changes to swift that prevent `fileprivate` or `private` methods to be called. Lastly I had to add some `!` for the `strtod` call.
It works for me now, maybe you could review the changes or test in your own branch. Thanks for your great work!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/postmates/pmjson/12)
<!-- Reviewable:end -->
